### PR TITLE
Add Dockerfile and entrypoint script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM maven:3.6-jdk-11 AS builder
 WORKDIR /app
 ENV GRPC_HEALTH_PROBE_VERSION=v0.3.2
 RUN wget -qOgrpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x grpc_health_probe && \
     git clone https://github.com/OpenNMS/grpc-server.git && \
     cd grpc-server && \
     git checkout -b feature/health-check origin/feature/health-check && \
@@ -12,6 +11,6 @@ FROM openjdk:11.0-jre-slim
 COPY --from=builder /app/grpc-server/target/grpc-ipc-server.jar /
 COPY --from=builder /app/grpc_health_probe /bin
 COPY docker-entrypoint.sh /
-RUN useradd grpc
+RUN useradd grpc && chmod +x /bin/grpc_health_probe
 USER grpc
 ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.6-jdk-8 AS builder
+WORKDIR /app
+RUN git clone https://github.com/OpenNMS/grpc-server.git && \
+    cd grpc-server && \
+    mvn package
+
+FROM openjdk:8-jdk-slim
+COPY --from=builder /app/grpc-server/target/grpc-ipc-server.jar /
+COPY docker-entrypoint.sh /
+ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6-jdk-8 AS builder
+FROM maven:3.6-jdk-11 AS builder
 WORKDIR /app
 ENV GRPC_HEALTH_PROBE_VERSION=v0.3.2
 RUN wget -qOgrpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
@@ -8,7 +8,7 @@ RUN wget -qOgrpc_health_probe https://github.com/grpc-ecosystem/grpc-health-prob
     git checkout -b feature/health-check origin/feature/health-check && \
     mvn package
 
-FROM openjdk:8-jdk-slim
+FROM openjdk:11.0-jre-slim
 COPY --from=builder /app/grpc-server/target/grpc-ipc-server.jar /
 COPY --from=builder /app/grpc_health_probe /bin
 COPY docker-entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
 FROM maven:3.6-jdk-8 AS builder
 WORKDIR /app
-RUN git clone https://github.com/OpenNMS/grpc-server.git && \
+ENV GRPC_HEALTH_PROBE_VERSION=v0.3.2
+RUN wget -qOgrpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
+    chmod +x grpc_health_probe && \
+    git clone https://github.com/OpenNMS/grpc-server.git && \
     cd grpc-server && \
+    git checkout -b feature/health-check origin/feature/health-check && \
     mvn package
 
 FROM openjdk:8-jdk-slim
 COPY --from=builder /app/grpc-server/target/grpc-ipc-server.jar /
+COPY --from=builder /app/grpc_health_probe /bin
 COPY docker-entrypoint.sh /
+RUN useradd grpc
+USER grpc
 ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+# =====================================================================
+# Build script running OpenNMS gRPC Server in Docker environment
+# =====================================================================
+
+function join { local IFS="$1"; shift; echo "$*"; }
+
+TLS_ENABLED=${TLS_ENABLED-false}
+IFS=$'\n'
+OPTIONS=(
+  "-Dorg.opennms.instance.id=${INSTANCE_ID-OpenNMS}"
+  "-Dtls.enabled=${TLS_ENABLED}"
+  "-Dport=${PORT-8990}"
+  "-Dmax.message.size=${MAX_MESSAGE_SIZE-10485760}"
+)
+if [ -z ${SERVER_PRIVATE_KEY+x} ]; then
+  OPTIONS+=(-Dserver.private.key.filepath=${SERVER_PRIVATE_KEY})
+fi
+if [ -z ${SERVER_CERT+x} ]; then
+  OPTIONS+=(-Dserver.cert.filepath=${SERVER_CERT})
+fi
+if [ -z ${CLIENT_CERT+x} ]; then
+  OPTIONS+=(-Dclient.cert.filepath=${CLIENT_CERT})
+fi
+
+for VAR in $(env)
+do
+  env_var=$(echo "$VAR" | cut -d= -f1)
+  if [[ $env_var =~ ^PRODUCER_ || $env_var =~ ^CONSUMER_ ]]; then
+    key="org.opennms.core.ipc.grpc.kafka."$(echo "$env_var" | tr '[:upper:]' '[:lower:]' | tr _ .)
+    val=${!env_var}
+    echo "[Configuring] '$key'='$val'"
+    OPTIONS+=("-D$key=$val")
+  fi
+done
+
+export JAVA_TOOL_OPTIONS="${JAVA_OPTS} $(join ' ' ${OPTIONS[@]})"
+exec java -jar /grpc-ipc-server.jar ${BOOTSTRAP_SERVERS-localhost:9092}

--- a/pom.xml
+++ b/pom.xml
@@ -28,10 +28,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
         </configuration>
       </plugin>
       <plugin>
@@ -112,6 +111,11 @@
   </build>
 
   <dependencies>
+    <dependency> <!-- Required for Java 11 -->
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>


### PR DESCRIPTION
To be able to use the gRPC server with Docker or Kubernetes, I've added a simple Dockerfile with two phases, one to compile the JAR (to avoid requiring having a JDK installed), and another to build the image with the compiled JAR and the entry point script.

The entry point script exposes all possible variables that can be passed to the gRPC server via environment variables.

The generated image is how I've been testing the gRPC in Docker and Kubernetes so far.