### PR TITLE
Implement gRPC health-check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,11 @@
       <version>${grpcVersion}</version>
     </dependency>
     <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-services</artifactId>
+      <version>${grpcVersion}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>3.9.0</version>


### PR DESCRIPTION
While testing the gRPC server in Kubernetes, I noticed that for some reason the readiness and liveness probe based on the `tcpSocket` probe is not working.

I found this article that explains the best way to perform health checks for gRPC services:

https://kubernetes.io/blog/2018/10/01/health-checking-grpc-servers-on-kubernetes/

The changes in this PR use the implementation available on `grpc-java` for the health check described above. The solution was tested using the command `grpc_health_probe` which is also described in the above link.