### PR TITLE
Add CircleCI with publish and release workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,8 +129,8 @@ jobs:
           name: Load Docker Container Image file
           command: |
             docker image load -i target/grpc-server.oci
-            docker tag grpc-server:latest docker.io/indigo/grpc-server:$(cat version.txt)
-            docker push docker.io/indigo/grpc-server:$(cat version.txt)
+            docker tag grpc-server:latest docker.io/opennms/grpc-server:$(cat version.txt)
+            docker push docker.io/opennms/grpc-server:$(cat version.txt)
 
   publish-github:
       executor: go-executor
@@ -142,7 +142,7 @@ jobs:
             command: |
               go get -u github.com/tcnksm/ghr
         - run:
-            name: Gather files for release-27.x
+            name: Gather files for release
             command: |
               mkdir gh-release
               zip -9 gh-release/grpc-ipc-server.jar.zip target/grpc-ipc-server.jar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,150 @@
+version: 2.1
+
+executors:
+  docker-executor:
+    docker:
+      - image: docker:stable-git
+  maven-executor:
+    docker:
+      - image: opennms/maven:11.0.9.11-3.6.3-b5957
+  go-executor:
+    docker:
+      - image: circleci/golang
+
+commands:
+  dockerhub-login:
+    description: "Connect to DockerHub"
+    steps:
+      - run:
+          name: Login to DockerHub
+          command: |
+            docker login -u ${CONTAINER_REGISTRY_LOGIN} -p ${CONTAINER_REGISTRY_PASS}
+
+workflows:
+  build:
+    jobs:
+      - build
+      - package:
+          requires:
+            - build
+      - oci-image:
+          context:
+            - no42-credentials
+          requires:
+            - build
+      - publish-github:
+          context:
+            - no42-credentials
+          filters:
+            branches:
+              only:
+                - /^release-.*/
+          requires:
+            - package
+      - publish-dockerhub:
+          context:
+            - no42-credentials
+          filters:
+            branches:
+              only:
+                - /^release-.*/
+          requires:
+            - oci-image
+
+jobs:
+  build:
+    executor: maven-executor
+    steps:
+      - checkout
+      - restore_cache:
+          key: grpc-server-repository-{{ checksum "pom.xml" }}
+      - run:
+          name: Generate version number for this build
+          command: |
+            BRANCH_TAG=$(echo ${CIRCLE_BRANCH/release-/} | tr '[:upper:]' '[:lower:]')
+            echo "export VERSION=${BRANCH_TAG/\//-}-b${CIRCLE_BUILD_NUM}" >> ${BASH_ENV}
+      - run:
+          name: Compile and run tests
+          command: |
+            make compile
+      - save_cache:
+          key: grpc-server-repository-{{ checksum "pom.xml" }}
+          paths:
+            - ~/.m2
+      - run:
+          name: Persist version number
+          command: |
+            echo ${VERSION} > version.txt
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project
+
+  package:
+    executor: maven-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - run:
+          name: Package Java archive
+          command: |
+            make package
+      - store_artifacts:
+          path: target/grpc-ipc-server.jar
+      - persist_to_workspace:
+          root: ~/
+          paths: project/target
+
+  oci-image:
+    executor: docker-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - run:
+          name: Build Docker Container Image
+          command: |
+            docker build -t grpc-server .
+      - run:
+          name: Persist Docker Container Image
+          command: |
+            docker image save grpc-server -o target/grpc-server.oci
+      - store_artifacts:
+          path: target/grpc-server.oci
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - project/target/grpc-server.oci
+
+  publish-dockerhub:
+    executor: docker-executor
+    steps:
+      - attach_workspace:
+          at: ~/
+      - setup_remote_docker:
+          docker_layer_caching: false
+      - dockerhub-login
+      - run:
+          name: Load Docker Container Image file
+          command: |
+            docker image load -i target/grpc-server.oci
+            docker tag grpc-server:latest docker.io/indigo/grpc-server:$(cat version.txt)
+            docker push docker.io/indigo/grpc-server:$(cat version.txt)
+
+  publish-github:
+      executor: go-executor
+      steps:
+        - attach_workspace:
+            at: ~/
+        - run:
+            name: Install ghr tool to create GitHub releases and upload artifacts
+            command: |
+              go get -u github.com/tcnksm/ghr
+        - run:
+            name: Gather files for release-27.x
+            command: |
+              mkdir gh-release
+              zip -9 gh-release/grpc-ipc-server.jar.zip target/grpc-ipc-server.jar
+              tar czf gh-release/grpc-ipc-server.jar.tar.gz target/grpc-ipc-server.jar
+              ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} $(cat version.txt) gh-release

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+## 
+# Makefile to build grpc-server
+##
+.PHONY: help deps-build compile package oci clean
+
+.DEFAULT_GOAL := package
+
+SHELL                := /bin/bash -o nounset -o pipefail -o errexit
+WORKING_DIRECTORY    := $(shell pwd)
+
+help:
+	@echo ""
+	@echo "Makefile to gRPC Kafka gateway"
+	@echo ""
+	@echo "Requirements:"
+	@echo "  * OpenJDK 11 JDK with java an javac in your search path"
+	@echo "  * Docker installed to build the container image"
+	@echo "  * Maven 3.6.x installed to compile and package the java binary"
+	@echo ""
+	@echo "Targets:"
+	@echo "  help:             Show this help"
+	@echo "  deps-build:       Test requirements to compile source and build OCI image"
+	@echo "  compile:          Validate, compile and run tests with Maven"
+	@echo "  package:          Package and assemble Java archive"
+	@echo "  oci:              Create OCI with docker"
+	@echo "  clean:            Delete all Maven build artifacts and OCI files"
+	@echo ""
+
+deps-build:
+	@command -v javac
+	@command -v mvn -v
+	@command -v docker
+
+compile:
+	@echo "Maven validate ..."
+	mvn validate
+	@echo "Maven compile ... "
+	mvn compile
+	@echo "Maven tests ..."
+	mvn verify
+
+package: compile
+	@echo "Maven package ..."
+	mvn package -DskipTests
+
+oci: package
+	@echo "Create OCI ..."
+	docker build -t grpc-server .
+
+clean:
+	mvn clean
+
+all: oci
+  


### PR DESCRIPTION
I've added a CircleCI pipeline that allows making a release with the following artifacts:

* Push tar.gz and .zip file from the executable Java jar file to the GitHub release page
* Push OCI image to docker.io/opennms/grpc-server

To make a release you have to push a release branch in the following format `release-x.y.z`. The version number x.y.z is used as the version number + the unique identified CircleCI build number to track the release to the build.

Every other branch pushes OCI and the JAR file as a build artifact in CircleCI and can be downloaded from there.

In CircleCI the following security context environment variables need to be initialized to push the release artifacts to GitHub and DockerHub:

* `CONTAINER_REGISTRY_LOGIN`: DockerHub user name
* `CONTAINER_REGISTRY_PASS`: DockerHub pass word
* `GITHUB_TOKEN`: GitHub API token which allows to make a release and upload artifacts to the GitHub release page